### PR TITLE
Upgrade RSpec suite to latest: selenium-webdriver 4.40 and appium_lib…

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,3 +8,4 @@ gem "selenium-webdriver", "4.40.0"
 gem "rspec", "~> 3.13.2"
 gem "test-unit", "~> 3.6"
 gem "rake", "~> 13.2"
+gem 'parallel'

--- a/Gemfile
+++ b/Gemfile
@@ -1,12 +1,10 @@
-# A sample Gemfile
+# frozen_string_literal: true
+
 source "https://rubygems.org"
 
-# gem "rails"
-
-gem "rake"
-gem "selenium-webdriver" , "4.1.0"
-gem "rspec-core", "~> 3.4.4"
-gem "rspec"
-gem "parallel"
-gem "appium_lib"
-gem "ffi"
+# Matching the highest versions found on your system
+gem "appium_lib", "16.1.1"
+gem "selenium-webdriver", "4.40.0"
+gem "rspec", "~> 3.13.2"
+gem "test-unit", "~> 3.6"
+gem "rake", "~> 13.2"

--- a/README.md
+++ b/README.md
@@ -151,7 +151,25 @@ app_caps:
     "platformVersion": "10"
     "app": "APP_URL"   #Add the app (.apk) url here
 ```
+**W3C Capabilities**
 
+```bash
+    caps = {
+      "platformName" => "Android",
+      "appium:deviceName" => "Galaxy S24",
+      "appium:platformVersion" => "14",
+      "appium:app" => "lt://proverbial-android",
+      "appium:isRealMobile" => true,
+      "appium:automationName" => "UiAutomator2",
+      "lt:options" => {
+        "user" => username,
+        "accessKey" => accessToken,
+        "build" => "RSpec-Android-Build",
+        "name" => "RSpec Sample Test",
+        "w3c" => true
+      }
+    }
+```
 </TabItem>
 
 </Tabs>
@@ -172,7 +190,7 @@ bundle install
 2. Execute the following command to run single test on LambdaTest platform:
 
 ```bash
-bundle exec rake single
+bundle exec rspec spec/app_automation.rb
 ```
 
 > In order to run parallel tests, run `bundle exec rake parallel`.

--- a/scripts/lambdatest.rb
+++ b/scripts/lambdatest.rb
@@ -1,70 +1,36 @@
-require 'yaml'
-require 'rspec'
 require 'appium_lib'
-
-TASK_ID = (ENV['TASK_ID'] || 0).to_i
-CONFIG_NAME = ENV['CONFIG_NAME'] || 'single'
-
-CONFIG = YAML.load(File.read(File.join(File.dirname(__FILE__), "../config/#{CONFIG_NAME}.config.yml")))
-CONFIG['user'] = ENV['LT_USERNAME'] || CONFIG['user']
-CONFIG['key'] = ENV['LT_ACCESS_KEY'] || CONFIG['key']
-
-
-
+require 'rspec'
 
 RSpec.configure do |config|
-  config.around(:example) do |example|
-    @caps = CONFIG['common_caps'].merge(CONFIG['browser_caps'][TASK_ID])
-    @caps["name"] = ENV['name'] || example.metadata[:name] || example.metadata[:file_path].split('/').last.split('.').first
+  config.before(:each) do
+    username = ENV['LT_USERNAME']
+    accessToken = ENV['LT_ACCESS_KEY']
 
-    puts @caps.inspect
-    b= @caps["deviceName"].inspect
-    v= @caps["isRealMobile"].inspect
-    p= @caps["platform"].inspect
-    c=@caps["platformVersion"].inspect
-    app=@caps["app"].inspect
-
-
-    deviceName= b.gsub("\"", "")
-    platformVersion=c.gsub("\"", "")
-    isRealMobile= v.gsub("\"", "")
-    platform= p.gsub("\"", "")
-    app=app.gsub("\"", "")
-     
-
-    caps={ 
-  
-      "LT:Options" => {
-
-   
-    "build" => "Ruby RSpec",
-    "name" => "Sample Test",
-    "platformName" => platform,
-    "isRealMobile" => isRealMobile,
-    "deviceName" => deviceName,
-    "platformVersion" => platformVersion,
-    "app" => app,
-    "w3c" => true
-    },
-    
+    caps = {
+      "platformName" => "Android",
+      "appium:deviceName" => "Galaxy S21 5G",
+      "appium:platformVersion" => "11",
+      "appium:app" => "lt://proverbial-android",
+      "appium:isRealMobile" => true,
+      "appium:automationName" => "UiAutomator2",
+      "lt:options" => {
+        "user" => username,
+        "accessKey" => accessToken,
+        "build" => "RSpec-Android-Build",
+        "name" => "RSpec Sample Test",
+        "w3c" => true
+      }
     }
 
-    
+    appium_lib_options = {
+      server_url: "https://#{username}:#{accessToken}@mobile-hub.lambdatest.com/wd/hub"
+    }
 
-    #@driver = Selenium::WebDriver.for(:remote,:url => "https://#{CONFIG['user']}:#{CONFIG['key']}@#{CONFIG['server']}/wd/hub",:capabilities => @caps)
+    @appium_driver = Appium::Driver.new({ caps: caps, appium_lib: appium_lib_options }, true)
+    @driver = @appium_driver.start_driver
+  end
 
-    appium_driver = Appium::Driver.new({
-      'caps' => caps,
-      'appium_lib' => {
-          :server_url => "https://#{CONFIG['user']}:#{CONFIG['key']}@#{CONFIG['server']}/wd/hub"
-      }}, true)
-    @driver = appium_driver.start_driver
-    puts @driver.inspect
-    session_id = @driver.session_id
-    begin
-      example.run
-    ensure
-      @driver.quit
-    end
+  config.after(:each) do
+    @driver.quit if @driver
   end
 end

--- a/scripts/lambdatest.rb
+++ b/scripts/lambdatest.rb
@@ -8,8 +8,8 @@ RSpec.configure do |config|
 
     caps = {
       "platformName" => "Android",
-      "appium:deviceName" => "Galaxy S21 5G",
-      "appium:platformVersion" => "11",
+      "appium:deviceName" => "Galaxy S24",
+      "appium:platformVersion" => "14",
       "appium:app" => "lt://proverbial-android",
       "appium:isRealMobile" => true,
       "appium:automationName" => "UiAutomator2",


### PR DESCRIPTION
Ruby 3.4 Compatibility: Updated Gemfile to use selenium-webdriver 4.40 and appium_lib 16.1.

W3C Migration: Refactored driver setup to use lt:options and appium: prefixes (fixes 400 Bad Request errors).

Cleanup: Removed legacy Gemfile.lock files to resolve dependency conflicts.